### PR TITLE
Simplify PerDbContextCompiledQueryCache and its setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspired by and partially based on the blog post: https://weblogs.asp.net/ricard
 # How to enable LazyLoading in EF Core?
 
 1. Reference the `Microsoft.EntityFrameworkCore.LazyLoading` NuGet package (https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.LazyLoading/).
-2. Create (or modify an existing) DbContext factory. Include the lines inside the two `if(_isLazy)` blocks in your DbContext factory (3 lines total - 2 before building the DbContext, and 1 after):
+2. Create (or modify an existing) DbContext factory. Include the lines inside the two `if(_isLazy)` blocks in your DbContext factory (4 lines total - 3 before building the DbContext, and 1 after):
 ```c#
 public class MyDbContextFactory : IDbContextFactory<MyDbContext>
 {
@@ -38,7 +38,6 @@ public class MyDbContextFactory : IDbContextFactory<MyDbContext>
         if (_isLazy)
         {
             (ctx.GetService<Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource>() as Microsoft.EntityFrameworkCore.LazyLoading.Metadata.Internal.LazyLoadingEntityMaterializerSource<MyDbContext>).SetDbContext(ctx);
-            (ctx.GetService<Microsoft.EntityFrameworkCore.Query.Internal.ICompiledQueryCache>() as Microsoft.EntityFrameworkCore.LazyLoading.Query.Internal.PerDbContextCompiledQueryCache).SetDbContext(ctx);
         }
 
         return ctx;

--- a/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Data/Factory/SchoolContextFactory.cs
+++ b/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Data/Factory/SchoolContextFactory.cs
@@ -40,8 +40,9 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Sample.Data.Factory
             // LazyLoading specific
             if (_isLazy)
             {
+                // ReSharper disable once PossibleNullReferenceException
                 (ctx.GetService<IEntityMaterializerSource>() as LazyLoadingEntityMaterializerSource<SchoolContext>).SetDbContext(ctx);
-                (ctx.GetService<ICompiledQueryCache>() as PerDbContextCompiledQueryCache).SetDbContext(ctx);
+                // ReSharper restore PossibleNullReferenceException
             }
 
             return ctx;

--- a/src/Microsoft.EntityFrameworkCore.LazyLoading/Query/Internal/PerDbContextCompiledQueryCache.cs
+++ b/src/Microsoft.EntityFrameworkCore.LazyLoading/Query/Internal/PerDbContextCompiledQueryCache.cs
@@ -9,16 +9,12 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Query.Internal
 {
     public class PerDbContextCompiledQueryCache : CompiledQueryCache
     {
-        private DbContext _dbContext;
+        private ICurrentDbContext _dbContext;
 
         public PerDbContextCompiledQueryCache(IDbContextServices contextServices)
             : base(contextServices)
         {
-        }
-
-        public void SetDbContext(DbContext dbContext)
-        {
-            _dbContext = dbContext;
+            _dbContext = contextServices.CurrentContext;
         }
 
         public override Func<QueryContext, IAsyncEnumerable<TResult>> GetOrAddAsyncQuery<TResult>(object cacheKey, Func<Func<QueryContext, IAsyncEnumerable<TResult>>> compiler)

--- a/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Data/SchoolContextFactory.cs
+++ b/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Data/SchoolContextFactory.cs
@@ -46,7 +46,6 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Tests.Data
             // LazyLoading specific
             // ReSharper disable PossibleNullReferenceException
             (ctx.GetService<IEntityMaterializerSource>() as LazyLoadingEntityMaterializerSource<SchoolContext>).SetDbContext(ctx);
-            (ctx.GetService<ICompiledQueryCache>() as PerDbContextCompiledQueryCache).SetDbContext(ctx);
             // ReSharper restore PossibleNullReferenceException
 
             ctx.Database.EnsureCreated();


### PR DESCRIPTION
Passing DbContext to PerDbContextCompiledQueryCache is unnecessary as IDbContextServices constructor already contains it as an ICurrentDbContext (therefore it can be set in constructor).