### PR TITLE
Fix issue #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ public class Child
     {
         get
         {
-            return _parentLazy.GetValue(this, nameof(Parent));
+            return _parentLazy.GetValue(this);
         }
         set
         {

--- a/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/Course.cs
+++ b/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/Course.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Sample.Models
         {
             get
             {
-                return _departmentLazy.GetValue(this, nameof(Department));
+                return _departmentLazy.GetValue(this);
             }
             set
             {

--- a/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/CourseAssignment.cs
+++ b/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/CourseAssignment.cs
@@ -9,7 +9,7 @@
         {
             get
             {
-                return _instructorLazy.GetValue(this, nameof(Instructor));
+                return _instructorLazy.GetValue(this);
             }
             set
             {
@@ -21,7 +21,7 @@
         {
             get
             {
-                return _courseLazy.GetValue(this, nameof(Course));
+                return _courseLazy.GetValue(this);
             }
             set
             {

--- a/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/Department.cs
+++ b/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/Department.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Sample.Models
         {
             get
             {
-                return _administratorLazy.GetValue(this, nameof(Administrator));
+                return _administratorLazy.GetValue(this);
             }
             set
             {

--- a/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/Enrollment.cs
+++ b/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/Enrollment.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Sample.Models
         {
             get
             {
-                return _courseLazy.GetValue(this, nameof(Course));
+                return _courseLazy.GetValue(this);
             }
             set
             {
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Sample.Models
         {
             get
             {
-                return _studentLazy.GetValue(this, nameof(Student));
+                return _studentLazy.GetValue(this);
             }
             set
             {

--- a/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/Instructor.cs
+++ b/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/Instructor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Sample.Models
         {
             get
             {
-                return _officeAssignmentLazy.GetValue(this, nameof(OfficeAssignment));
+                return _officeAssignmentLazy.GetValue(this);
             }
             set
             {

--- a/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/OfficeAssignment.cs
+++ b/samples/Microsoft.EntityFrameworkCore.LazyLoading.Sample/Models/OfficeAssignment.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Sample.Models
         {
             get
             {
-                return _instructorLazy.GetValue(this, nameof(Instructor));
+                return _instructorLazy.GetValue(this);
             }
             set
             {

--- a/src/Microsoft.EntityFrameworkCore.LazyLoading/LazyReference.cs
+++ b/src/Microsoft.EntityFrameworkCore.LazyLoading/LazyReference.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+﻿using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.LazyLoading.Exceptions;
 using Microsoft.EntityFrameworkCore.LazyLoading.Internal;
 
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading
             _isLoaded = true;
         }
 
-        public T GetValue(object parent, string referenceName)
+        public T GetValue(object parent, [CallerMemberName] string referenceName = null)
         {
             if (_ctx == null || _isLoaded || _isLoading)
             {

--- a/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/Course.cs
+++ b/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/Course.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Tests.Models
         private readonly LazyReference<Department> _departmentLazy = new LazyReference<Department>();
         public Department Department
         {
-            get => _departmentLazy.GetValue(this, nameof(Department));
+            get => _departmentLazy.GetValue(this);
             set => _departmentLazy.SetValue(value);
         }
 

--- a/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/CourseAssignment.cs
+++ b/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/CourseAssignment.cs
@@ -7,13 +7,13 @@
         private readonly LazyReference<Instructor> _instructorLazy = new LazyReference<Instructor>();
         public Instructor Instructor
         {
-            get => _instructorLazy.GetValue(this, nameof(Instructor));
+            get => _instructorLazy.GetValue(this);
             set => _instructorLazy.SetValue(value);
         }
         private readonly LazyReference<Course> _courseLazy = new LazyReference<Course>();
         public Course Course
         {
-            get => _courseLazy.GetValue(this, nameof(Course));
+            get => _courseLazy.GetValue(this);
             set => _courseLazy.SetValue(value);
         }
     }

--- a/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/Department.cs
+++ b/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/Department.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Tests.Models
 
         public Instructor Administrator
         {
-            get => _administratorLazy.GetValue(this, nameof(Administrator));
+            get => _administratorLazy.GetValue(this);
             set => _administratorLazy.SetValue(value);
         }
         public ICollection<Course> Courses { get; set; }

--- a/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/Enrollment.cs
+++ b/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/Enrollment.cs
@@ -18,13 +18,13 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Tests.Models
         private readonly LazyReference<Course> _courseLazy = new LazyReference<Course>();
         public Course Course
         {
-            get => _courseLazy.GetValue(this, nameof(Course));
+            get => _courseLazy.GetValue(this);
             set => _courseLazy.SetValue(value);
         }
         private readonly LazyReference<Student> _studentLazy = new LazyReference<Student>();
         public Student Student
         {
-            get => _studentLazy.GetValue(this, nameof(Student));
+            get => _studentLazy.GetValue(this);
             set => _studentLazy.SetValue(value);
         }
     }

--- a/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/Instructor.cs
+++ b/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/Instructor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Tests.Models
         private readonly LazyReference<OfficeAssignment> _officeAssignmentLazy = new LazyReference<OfficeAssignment>();
         public OfficeAssignment OfficeAssignment
         {
-            get => _officeAssignmentLazy.GetValue(this, nameof(OfficeAssignment));
+            get => _officeAssignmentLazy.GetValue(this);
             set => _officeAssignmentLazy.SetValue(value);
         }
     }

--- a/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/OfficeAssignment.cs
+++ b/tests/Microsoft.EntityFrameworkCore.LazyLoading.Tests/Models/OfficeAssignment.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.LazyLoading.Tests.Models
         private readonly LazyReference<Instructor> _instructorLazy = new LazyReference<Instructor>();
         public Instructor Instructor
         {
-            get => _instructorLazy.GetValue(this, nameof(Instructor));
+            get => _instructorLazy.GetValue(this);
             set => _instructorLazy.SetValue(value);
         }
     }


### PR DESCRIPTION
Simplify API of LazyReference<T> by using [CallerMemberName] attribute #21:
```cs
get => _parentLazy.GetValue(this, nameof(Parent));
// to
get => _parentLazy.GetValue(this);
```